### PR TITLE
fix: docker compose shell command

### DIFF
--- a/tests/docker_service.py
+++ b/tests/docker_service.py
@@ -63,7 +63,7 @@ class DockerServiceRegistry:
 
     def run_command(self, *args: str) -> None:
         command = [*self._base_command, *args]
-        subprocess.run(command, check=True, capture_output=True)
+        subprocess.run(command, check=True, capture_output=True)  # noqa: S603
 
     async def start(
         self,

--- a/tests/docker_service.py
+++ b/tests/docker_service.py
@@ -4,7 +4,6 @@ import asyncio
 import os
 import re
 import subprocess
-import sys
 import timeit
 from typing import TYPE_CHECKING, Any
 
@@ -63,10 +62,8 @@ class DockerServiceRegistry:
         raise ValueError(f'Invalid value for DOCKER_HOST: "{docker_host}".')
 
     def run_command(self, *args: str) -> None:
-        if sys.platform == "darwin":
-            subprocess.call([*self._base_command, *args], shell=True)  # noqa: S602
-        else:
-            subprocess.run([*self._base_command, *args], check=True, capture_output=True)  # noqa: S603
+        command = [*self._base_command, *args]
+        subprocess.run(command, check=True, capture_output=True)
 
     async def start(
         self,


### PR DESCRIPTION
Currently integration tests fail due to the `docker_service` timing out which itself is a result of the`docker compose` command not running correctly due to a shell error. This works on mac 13.2 with zsh & ohmyzsh. 

However I'm getting this on my own branch for Github Actions: 
<img width="1219" alt="Screenshot 2023-07-28 at 2 16 00 PM" src="https://github.com/cofin/litestar-fullstack/assets/9613083/abec512b-e87a-45dd-a628-30b03070531f">

Unsure if it's related to the changes on my PR. 
