### PR TITLE
fix: update `cp .env` command in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ This command does the following:
 There is a sample `.env` file located in the root of the repository.
 
 ```bash
-cp env.example .env
+cp .env.example .env
 ```
 
 **Note** `SECRET_KEY`, `DATABASE_URI`, and `REDIS_URL` are the most important config settings. Be sure to set this properly.


### PR DESCRIPTION
There was a missing dot in the command