### PR TITLE
infra: set host to `0.0.0.0` instead of `127.0.0.1`.  This enables external access to the container.

### DIFF
--- a/deploy/docker/dev/Dockerfile
+++ b/deploy/docker/dev/Dockerfile
@@ -88,7 +88,7 @@ COPY tests/ tests/
 COPY src src/
 RUN poetry install $POETRY_INSTALL_ARGS
 STOPSIGNAL SIGINT
-EXPOSE 8000/tcp
+EXPOSE 8000
 ENTRYPOINT ["tini","--" ]
-CMD [ "litestar","run"]
+CMD [ "litestar","run","--host","0.0.0.0"]
 VOLUME /workspace/app

--- a/deploy/docker/run/Dockerfile
+++ b/deploy/docker/run/Dockerfile
@@ -85,7 +85,7 @@ RUN pip install --quiet --disable-pip-version-check --no-deps --requirement=/tmp
 RUN pip install --quiet --disable-pip-version-check --no-deps /tmp/*.whl
 USER nonroot
 STOPSIGNAL SIGINT
-EXPOSE 8000/tcp
+EXPOSE 8000
 ENTRYPOINT ["tini","--" ]
-CMD [ "litestar","run"]
+CMD [ "litestar","run","--host","0.0.0.0"]
 VOLUME /workspace/app

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -25,7 +25,7 @@ services:
         # remove this to build for production.
         POETRY_INSTALL_ARGS: --with=dev,docs,lint
     image: app:latest-dev
-    command: litestar run --reload
+    command: litestar run --reload --host 0.0.0.0 --port 8000
     restart: always
     <<: *development-volumes
   worker:


### PR DESCRIPTION
This addresses an issue where the services launched in the containers are bound to listen on 127.0.0.1 instead of 0.0.0.0.

This prevented extenal access to container in most common network configurations.